### PR TITLE
Version 1.0.0.rc3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,7 @@ gem 'therubyracer', require: 'v8'
 group :test do
   gem 'rspec-rails'
   gem 'rspec-its'
-  gem 'factory_girl_rails'
   gem 'database_cleaner'
-  gem 'capybara'
 end
 
 gem 'bootstrap-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,12 +37,6 @@ GEM
       sass (>= 3.2.19)
     builder (3.2.2)
     cancancan (1.12.0)
-    capybara (2.4.4)
-      mime-types (>= 1.16)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -61,11 +55,6 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.6.0)
-    factory_girl (4.5.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.5.0)
-      factory_girl (~> 4.5.0)
-      railties (>= 3.0.0)
     font-awesome-rails (4.4.0.0)
       railties (>= 3.2, < 5.0)
     haml (4.0.7)
@@ -194,8 +183,6 @@ GEM
       json (>= 1.8.0)
     warden (1.2.3)
       rack (>= 1.0)
-    xpath (2.0.0)
-      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -203,11 +190,9 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   cancancan (~> 1.12)
-  capybara
   coffee-rails (~> 4.0.0)
   database_cleaner
   devise (~> 3.5)
-  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   mysql2

--- a/app/controllers/api/v1/licenses_controller.rb
+++ b/app/controllers/api/v1/licenses_controller.rb
@@ -2,13 +2,11 @@ module Api::V1
   class LicensesController < ModelController
 
     def select_resources
-      resource_class.where(resources_params).select(:id, :code, :title, :url)
+      resource_class.select(:id, :title, :url)
     end
 
-    private
-
-    def resources_params
-      params.permit(:id, :code, :url, :title)
+    def find_params
+      params.permit(:url, :title)
     end
 
   end

--- a/app/controllers/api/v1/model_controller.rb
+++ b/app/controllers/api/v1/model_controller.rb
@@ -5,6 +5,7 @@ module Api::V1
     attr_reader :resource, :resources
     before_action :index_resources, only: :index
     before_action :show_resource, only: :show
+    before_action :find_resource, only: :find
 
     # GET /api/{plural_resource_name}
     def index
@@ -13,6 +14,11 @@ module Api::V1
 
     # GET /api/{plural_resource_name}/{id}
     def show
+      render json: resource
+    end
+
+    # GET /api/{plural_resource_name}/find?{params}
+    def find
       render json: resource
     end
 
@@ -34,11 +40,11 @@ module Api::V1
     private
 
     def show_resource
-      @resource = find_resource
+      @resource = resource_class.find(show_param)
     end
 
     def find_resource
-      resource_class.find(params[:id])
+      @resource = resource_class.find_by!(find_params)
     end
 
     def index_resources
@@ -47,6 +53,14 @@ module Api::V1
 
     def select_resources
       resource_class.all
+    end
+
+    def show_param
+      params.require(:id)
+    end
+
+    def find_params
+      raise NotImplementedError, "API model controllers must implement private #find_params method."
     end
 
   end

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,6 +1,6 @@
 class License < ActiveRecord::Base
 
-  validates :code, presence: true, uniqueness: true
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: true
+  validates :url, presence: true, uniqueness: true
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: {format: 'json'} do
     scope module: :v1, constraints: DdrAux::ApiConstraints.new(version: 1, default: true) do
-      resources :licenses, only: [:index, :show]
+      resources :licenses, only: [:index, :show] do
+        get 'find', on: :collection
+      end
     end
   end
 

--- a/db/migrate/20150910133650_drop_code_from_licenses.rb
+++ b/db/migrate/20150910133650_drop_code_from_licenses.rb
@@ -1,0 +1,5 @@
+class DropCodeFromLicenses < ActiveRecord::Migration
+  def change
+    remove_column :licenses, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904204735) do
+ActiveRecord::Schema.define(version: 20150910133650) do
 
   create_table "licenses", force: true do |t|
-    t.string   "code"
     t.string   "title"
     t.string   "url"
     t.text     "terms",      limit: 65535

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,22 +2,27 @@
 # Licenses
 #
 License.create(
-  code: "cc-by-4.0",
   title: "Creative Commons Attribution 4.0 International",
-  url: "https://creativecommons.org/licenses/by/4.0/"
+  url: "https://creativecommons.org/licenses/by/4.0/",
+  terms: <<-EOS
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+EOS
 )
 License.create(
-  code: "cc-by-nc-4.0",
   title: "Creative Commons Attribution-NonCommercial 4.0 International",
-  url: "https://creativecommons.org/licenses/by-nc/4.0/"
+  url: "https://creativecommons.org/licenses/by-nc/4.0/",
+  terms: <<-EOS
+<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.
+EOS
 )
 License.create(
-  code: "cc-by-nc-nd-4.0",
   title: "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International",
-  url: "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+  url: "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+  terms: <<-EOS
+<a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.
+EOS
 )
 License.create(
-  code: "cc0-1.0",
-  title: "Creative Commons 1.0 Universal (Public Domain Dedication)",
+  title: "Creative Commons 1.0 Universal (CC0 Public Domain Dedication)",
   url: "https://creativecommons.org/publicdomain/zero/1.0/"
 )

--- a/spec/controllers/api/v1/licenses_controller_spec.rb
+++ b/spec/controllers/api/v1/licenses_controller_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+module Api::V1
+  RSpec.describe LicensesController do
+
+    describe "#index" do
+      it "returns the list of all licenses" do
+        get :index
+        results = JSON.parse(response.body)
+        expect(results).to be_present
+        expect(results).to be_a(Array)
+      end
+    end
+
+    describe "#show" do
+      it "returns a license" do
+        get :show, id: 1
+        expect(response.response_code).to eq(200)
+        expect(response.content_type).to eq("application/json")
+        result = JSON.parse(response.body)
+        expect(result).to be_a(Hash)
+        expect(result["id"]).to eq(1)
+      end
+      it "return an error response when not found" do
+        get :show, id: "foo"
+        expect(response.response_code).to eq(404)
+        expect(response.content_type).to eq("text/plain")
+      end
+    end
+
+    describe "#find" do
+      it "returns a license" do
+        get :find, url: "https://creativecommons.org/publicdomain/zero/1.0/"
+        expect(response.response_code).to eq(200)
+        expect(response.content_type).to eq("application/json")
+        result = JSON.parse(response.body)
+        expect(result).to be_a(Hash)
+        expect(result["url"]).to eq("https://creativecommons.org/publicdomain/zero/1.0/")
+      end
+      it "return an error response when not found" do
+        get :find, url: "foo"
+        expect(response.response_code).to eq(404)
+        expect(response.content_type).to eq("text/plain")
+      end
+    end
+
+  end
+end

--- a/spec/factories/user_factories.rb
+++ b/spec/factories/user_factories.rb
@@ -1,7 +1,0 @@
-FactoryGirl.define do
-  factory :user do
-    sequence(:username) { |n| "person#{n}@example.com" }
-    email { |u| u.username }
-    password "secret"
-  end
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,5 +53,10 @@ RSpec.configure do |config|
 
   config.include Devise::TestHelpers, type: :controller
 
-  config.before(:suite) { DatabaseCleaner.clean }
+  config.before(:suite) do
+    DatabaseCleaner.clean
+    Dir.chdir(Rails.root) do
+      system({"RAILS_ENV"=>"test"}, "rake db:seed")
+    end
+  end
 end

--- a/spec/routing/api/v1/licenses_routing_spec.rb
+++ b/spec/routing/api/v1/licenses_routing_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe "API v1 licenses routing", type: :routing do
     expect(get: "/api/licenses/1").to route_to(controller: "api/v1/licenses", action: "show", id: "1", format: "json")
   end
 
+  it "routes /api/licenses/find to the api/v1/licenses controller" do
+    expect(get: "/api/licenses/find?url=https%3A%2F%2Fcreativecommons.org%2Fpublicdomain%2Fzero%2F1.0%2F").to route_to(controller: "api/v1/licenses", action: "find", url: "https://creativecommons.org/publicdomain/zero/1.0/", format: "json")
+  end
+
 end


### PR DESCRIPTION
Removes :code attribute from License (not used).
Adds #find action to Api::V1::ModelController.
Adds HTML terms to CC licenses in seed data (but not CC0).