### PR TITLE
Fixed Rails admin (broken on removed License :code field)

### DIFF
--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -3,4 +3,16 @@ class License < ActiveRecord::Base
   validates :title, presence: true, uniqueness: true
   validates :url, presence: true, uniqueness: true
 
+  rails_admin do
+    list do
+      field :title
+      field :url
+    end
+    edit do
+      configure :url do
+        read_only true
+      end
+    end
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,10 @@ class User < ActiveRecord::Base
     user
   end
 
+  rails_admin do
+    visible do
+      bindings[:controller].current_user.admin?
+    end
+  end
+
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -32,20 +32,4 @@ RailsAdmin.config do |config|
     # history_show
   end
 
-  ## Model config
-
-  config.model "License" do
-    list do
-      field :id
-      field :code
-      field :title
-    end
-  end
-
-  config.model "User" do
-    visible do
-      bindings[:controller].current_user.admin?
-    end
-  end
-
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,5 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  admin:
+    help:
+      license:
+        url: "%{help} Not editable after creation."


### PR DESCRIPTION
Rails admin model configs moved from initializer to models.